### PR TITLE
require node 16 due to adapter-code 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "type": "git",
     "url": "https://github.com/ciddi89/ioBroker.device-watcher"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4"
   },


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed on node 14. So this adapter requires node 16 or newer