### PR TITLE
Fix casing of "low" above low battery HTML table

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -582,7 +582,7 @@ const translations = {
 		'zh-cn': '链接质量设备',
 	},
 	low: {
-		en: 'low',
+		en: 'Low',
 		de: 'Niedrige',
 		ru: 'низкая',
 		pt: 'baixa',


### PR DESCRIPTION
<img width="193" height="44" alt="2026-01-11_13-57-50" src="https://github.com/user-attachments/assets/52075f29-e2b3-4991-8a87-c38cc87a0f71" />

This PR replaces "low" with "Low" in the HTML.